### PR TITLE
Add Fathom Analytics to site

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -168,5 +168,12 @@ const config = {
         additionalLanguages: ['solidity'],
       },
     },
+    scripts: [
+      {
+        src: "https://energetic-unwavering.juicebox.money/script.js",
+        defer: true,
+        "data-site": "UMYOVGDG",
+      },
+    ],
 };
 module.exports = config;


### PR DESCRIPTION
We use Fathom on juicebox.money. Let's add it to the blog and docs, too.

Analytics will be available here: https://app.usefathom.com/share/umyovgdg/info.juicebox.money

Password will be available in Discord.